### PR TITLE
add vulnerability-lookup.nse script, works similar to vulners.nse but…

### DIFF
--- a/tools/vulnerability-lookup.nse
+++ b/tools/vulnerability-lookup.nse
@@ -1,0 +1,199 @@
+description = [[
+For each available CPE the script prints out known vulns (links to the correspondent info) and correspondent CVSS scores.
+
+Uses the vulnerability-lookup API (https://vulnerability.circl.lu/api) from CIRCL (Computer Incident Response Center Luxembourg) 
+
+Based on https://svn.nmap.org/nmap/scripts/vulners.nse
+]]
+
+---
+-- @usage
+-- nmap -sV --script vulnerability-lookup [--script-args mincvss=<arg_val>] <target>
+--
+-- @args mincvss Limit CVEs shown to those with this CVSS score or greater.
+--
+-- @output
+--
+-- 53/tcp   open     domain             ISC BIND DNS
+-- | vulnerability-lookup:
+-- |   ISC BIND DNS:
+-- |     CVE-2012-1667    8.5    https://vulnerability.circl.lu/vuln/CVE-2012-1667
+-- |     CVE-2002-0651    7.5    https://vulnerability.circl.lu/vuln/CVE-2002-0651
+-- |     CVE-2002-0029    7.5    https://vulnerability.circl.lu/vuln/CVE-2002-0029
+-- |     CVE-2015-5986    7.1    https://vulnerability.circl.lu/vuln/CVE-2015-5986
+-- |     CVE-2010-3615    5.0    https://vulnerability.circl.lu/vuln/CVE-2010-3615
+-- |     CVE-2006-0987    5.0    https://vulnerability.circl.lu/vuln/CVE-2006-0987
+-- |_    CVE-2014-3214    5.0    https://vulnerability.circl.lu/vuln/CVE-2014-3214
+--
+-- @xmloutput
+-- <table key="cpe:2.3:a:isc:bind:9.8.2rc1">
+--   <table>
+--     <elem key="is_exploit">false</elem>
+--     <elem key="cvss">8.5</elem>
+--     <elem key="id">CVE-2012-1667</elem>
+--     <elem key="type">cve</elem>
+--   </table>
+--   <table>
+--     <elem key="is_exploit">false</elem>
+--     <elem key="cvss">7.8</elem>
+--     <elem key="id">CVE-2015-4620</elem>
+--     <elem key="type">cve</elem>
+--   </table>
+-- </table>
+
+author = 'luciano DOT righetti AT circl DOT lu'
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"vuln", "safe", "external"}
+
+
+local http = require "http"
+local json = require "json"
+local string = require "string"
+local table = require "table"
+local nmap = require "nmap"
+local stdnse = require "stdnse"
+local nsedebug = require("nsedebug")
+
+local mincvss=stdnse.get_script_args("mincvss")
+mincvss = tonumber(mincvss) or 0.0
+
+portrule = function(host, port)
+  local vers=port.version
+  return vers ~= nil and vers.version ~= nil
+end
+
+local cve_meta = {
+  __tostring = function(me)
+      return ("\t%s\t%s\thttps://vulnerability.circl.lu/vuln/%s%s"):format(me.id, me.cvss or "", me.id, me.is_exploit and '\t*EXPLOIT*' or '')
+  end,
+}
+
+---
+-- Return a string with all the found cve's and correspondent links
+--
+-- @param vulns a table with the parsed json response from the vulnerability-lookup server
+--
+function make_links(vulns)
+  local output = {}
+
+  nsedebug.tostr(vulns)
+  if not vulns or not vulns.cvelistv5 then
+    return
+  end
+
+  for _, vuln in ipairs(vulns.cvelistv5) do
+
+    score = 0
+
+    -- get the CVSS score
+    if vuln.containers.cna.metrics then
+      for k, m in pairs(vuln.containers.cna.metrics) do
+        -- nmap.log_write("stdout", nsedebug.tostr(m))
+        if m.cvssV3_1 then
+          score = m.cvssV3_1.baseScore
+        end
+        if m.cvssV3_0 then
+          score = m.cvssV3_0.baseScore
+        end
+      end
+    end
+
+    local v = {
+      id = vuln.cveMetadata.cveId,
+      type = vuln.dataType,
+      is_exploit = false, -- TODO: check if it is possible to get this info from the API
+      cvss = tonumber(score),
+    }
+
+    if not v.cvss or (v.cvss == 0 and v.is_exploit) or mincvss <= v.cvss then
+      setmetatable(v, cve_meta)
+      output[#output+1] = v
+    end
+  end
+
+  if #output > 0 then
+    -- Sort the acquired vulns by the CVSS score
+    table.sort(output, function(a, b)
+        return a.cvss > b.cvss or (a.cvss == b.cvss and a.id > b.id)
+      end)
+    return output
+  end
+
+  return output
+end
+
+
+---
+-- Issues the requests, receives json and parses it, calls <code>make_links</code> when successfull
+--
+-- @param cpe string, future value for the software query argument
+--
+function get_results(cpe)
+  local api_endpoint = "https://vulnerability.circl.lu/api/vulnerability/cpesearch/"
+  local vulns
+  local option={
+    header={
+      ['User-Agent'] = string.format('Vulnerability-Lookup NMAP Plugin')
+    },
+    any_af = true,
+    max_body_size = -1
+  }
+
+  local response = http.get_url(('%s%s'):format(api_endpoint, cpe), option)
+  local status = response.status
+
+  if status == nil then
+    -- Something went really wrong out there
+    -- According to the NSE way we will die silently rather than spam user with error messages
+    return
+  elseif status == 200 then
+    status, vulns = json.parse(response.body)
+    if status == true then
+      return make_links(vulns)
+    end
+  end
+  
+  return
+end
+
+---
+-- Calls <code>get_results</code> for type="cpe"
+--
+-- Takes the version number from the given <code>cpe</code> and tries to get the result.
+-- If none found, changes the given <code>cpe</code> a bit in order to possibly separate version number from the patch version
+-- And makes another attempt.
+-- Having failed returns an empty string.
+--
+-- @param cpe string, the given cpe
+--
+function get_vulns_by_cpe(cpe)
+  local output = get_results(cpe, "cpe")
+  
+  if output then
+    return output
+  end
+end
+
+action = function(host, port)
+  local tab=stdnse.output_table()
+  local changed=false
+  local response
+  local output
+
+  for i, cpe in ipairs(port.version.cpe) do
+    -- replace v2.2 prefix with v2.3
+    cpe = cpe:gsub("cpe:/", "cpe:2.3:")
+
+    output = get_vulns_by_cpe(cpe, port.version)
+    if output then
+      tab[cpe] = output
+      changed = true
+    end
+  end
+
+  if (not changed) then
+    return
+  end
+  return tab
+end
+


### PR DESCRIPTION
… uses the CIRCL https://vulnerability.circl.lu/api/ service

Sample usage:
```
$ nmap -sV -p 80 --script tools/vulnerability-lookup.nse --script-args=mincvss=5 localhost
Starting Nmap 7.80 ( https://nmap.org ) at 2024-12-19 15:04 CET
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00011s latency).

PORT   STATE SERVICE VERSION
80/tcp open  http    Apache httpd 2.4.49 ((Unix))
|_http-server-header: Apache/2.4.49 (Unix)
| vulnerability-lookup: 
|   cpe:2.3:a:apache:http_server:2.4.49: 
|     	CVE-2019-9517	7.5	https://vulnerability.circl.lu/vuln/CVE-2019-9517
|     	CVE-2017-12171	6.5	https://vulnerability.circl.lu/vuln/CVE-2017-12171
|     	CVE-2021-32791	5.9	https://vulnerability.circl.lu/vuln/CVE-2021-32791
|_    	CVE-2021-32785	5.3	https://vulnerability.circl.lu/vuln/CVE-2021-32785

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 10.36 seconds

```